### PR TITLE
support collator for natural sort

### DIFF
--- a/dist/sort.js
+++ b/dist/sort.js
@@ -29,6 +29,13 @@ const functionSorter = function(direction, sortBy, a, b) {
 };
 
 /**
+ * @example sort(users).asc(new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});y)
+ */
+const collatorSorter = function(direction, sortBy, a, b) {
+  return sortBy.compare(a, b) * direction;
+};
+
+/**
  * Used when we have sorting by multyple properties and when current sorter is function
  * @example sort(users).asc([p => p.address.city, p => p.firstName])
  */
@@ -108,6 +115,8 @@ const sort = function(direction, ctx, sortBy) {
     _sorter = stringSorter.bind(undefined, direction, sortBy);
   } else if (typeof sortBy === 'function') {
     _sorter = functionSorter.bind(undefined, direction, sortBy);
+  } else if (typeof sortBy === 'object' && sortBy instanceof Intl.Collator) {
+    _sorter = collatorSorter.bind(undefined, direction, sortBy);
   } else {
     _sorter = getMultiPropertySorter(sortBy[0])
       .bind(undefined, sortBy.shift(), sortBy, 0, direction);

--- a/integration_test/index.js
+++ b/integration_test/index.js
@@ -21,6 +21,13 @@ function run(err) {
   assert.deepEqual(sortEs6([1, 4, 3]).asc(), [1, 3, 4]);
   assert.deepEqual(sortEs5([1, 4, 3]).asc(), [1, 3, 4]);
   assert.deepEqual(sortEs5Min([1, 4, 3]).asc(), [1, 3, 4]);
+
+  assert.deepEqual(sortDefault(['A10', 'A1', 'B10', 'B2']).by([{
+    asc: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
+  }]), ['A1', 'A10', 'B2', 'B10']);
+
+  assert.deepEqual(sortDefault(['A10', 'A1', 'B10', 'B2']).asc([new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })]), ['A1', 'A10', 'B2', 'B10']);
+
   console.log('sort: SUCCESS');
 }
 


### PR DESCRIPTION
support use of a collator for natural sort


Basically allows one to pass in an instance of a localCompare collator to achieve natural sort. 
I believe it plugs in to all the formats currently supported (multiple sorts, etc). 

I only edited default (sort.js), wasnt sure what to do for es5 files.