### PR TITLE
Accept readonly arrays when inPlaceSorting is false

### DIFF
--- a/dist/sort.d.ts
+++ b/dist/sort.d.ts
@@ -17,7 +17,7 @@ export interface ISortByDescSorter<T> extends ISortInstanceOptions {
     desc: boolean | ISortBy<T>;
 }
 export declare type ISortByObjectSorter<T> = ISortByAscSorter<T> | ISortByDescSorter<T>;
-export declare const createNewSortInstance: (opts: ISortInstanceOptions) => <T>(_ctx: T[]) => {
+interface ISortFunctions<T> {
     /**
      * Sort array in ascending order.
      * @example
@@ -50,73 +50,11 @@ export declare const createNewSortInstance: (opts: ISortInstanceOptions) => <T>(
      * ]);
      */
     by(sortBy: ISortByObjectSorter<T> | ISortByObjectSorter<T>[]): T[];
-};
-export declare const sort: <T>(_ctx: T[]) => {
-    /**
-     * Sort array in ascending order.
-     * @example
-     * sort([3, 1, 4]).asc();
-     * sort(users).asc(u => u.firstName);
-     * sort(users).asc([
-     *   U => u.firstName
-     *   u => u.lastName,
-     * ]);
-     */
-    asc(sortBy?: ISortBy<T> | ISortBy<T>[]): T[];
-    /**
-     * Sort array in descending order.
-     * @example
-     * sort([3, 1, 4]).desc();
-     * sort(users).desc(u => u.firstName);
-     * sort(users).desc([
-     *   U => u.firstName
-     *   u => u.lastName,
-     * ]);
-     */
-    desc(sortBy?: ISortBy<T> | ISortBy<T>[]): T[];
-    /**
-     * Sort array in ascending or descending order. It allows sorting on multiple props
-     * in different order for each of them.
-     * @example
-     * sort(users).by([
-     *  { asc: u => u.score }
-     *  { desc: u => u.age }
-     * ]);
-     */
-    by(sortBy: ISortByObjectSorter<T> | ISortByObjectSorter<T>[]): T[];
-};
-export declare const inPlaceSort: <T>(_ctx: T[]) => {
-    /**
-     * Sort array in ascending order.
-     * @example
-     * sort([3, 1, 4]).asc();
-     * sort(users).asc(u => u.firstName);
-     * sort(users).asc([
-     *   U => u.firstName
-     *   u => u.lastName,
-     * ]);
-     */
-    asc(sortBy?: ISortBy<T> | ISortBy<T>[]): T[];
-    /**
-     * Sort array in descending order.
-     * @example
-     * sort([3, 1, 4]).desc();
-     * sort(users).desc(u => u.firstName);
-     * sort(users).desc([
-     *   U => u.firstName
-     *   u => u.lastName,
-     * ]);
-     */
-    desc(sortBy?: ISortBy<T> | ISortBy<T>[]): T[];
-    /**
-     * Sort array in ascending or descending order. It allows sorting on multiple props
-     * in different order for each of them.
-     * @example
-     * sort(users).by([
-     *  { asc: u => u.score }
-     *  { desc: u => u.age }
-     * ]);
-     */
-    by(sortBy: ISortByObjectSorter<T> | ISortByObjectSorter<T>[]): T[];
-};
+}
+export declare function createNewSortInstance(opts: ISortInstanceOptions & {
+    inPlaceSorting?: false;
+}): <T>(_ctx: readonly T[]) => ISortFunctions<T>;
+export declare function createNewSortInstance(opts: ISortInstanceOptions): <T>(_ctx: T[]) => ISortFunctions<T>;
+export declare const sort: <T>(_ctx: readonly T[]) => ISortFunctions<T>;
+export declare const inPlaceSort: <T>(_ctx: T[]) => ISortFunctions<T>;
 export {};

--- a/dist/sort.es.js
+++ b/dist/sort.es.js
@@ -74,55 +74,25 @@ var sortArray = function (order, ctx, sortBy, comparer) {
     }
     return ctx.sort(getSortStrategy(sortBy, comparer, order));
 };
-// >>> Public <<<
-var createNewSortInstance = function (opts) {
+function createNewSortInstance(opts) {
     var comparer = castComparer(opts.comparer);
     return function (_ctx) {
         var ctx = Array.isArray(_ctx) && !opts.inPlaceSorting
             ? _ctx.slice()
             : _ctx;
         return {
-            /**
-             * Sort array in ascending order.
-             * @example
-             * sort([3, 1, 4]).asc();
-             * sort(users).asc(u => u.firstName);
-             * sort(users).asc([
-             *   U => u.firstName
-             *   u => u.lastName,
-             * ]);
-             */
             asc: function (sortBy) {
                 return sortArray(1, ctx, sortBy, comparer);
             },
-            /**
-             * Sort array in descending order.
-             * @example
-             * sort([3, 1, 4]).desc();
-             * sort(users).desc(u => u.firstName);
-             * sort(users).desc([
-             *   U => u.firstName
-             *   u => u.lastName,
-             * ]);
-             */
             desc: function (sortBy) {
                 return sortArray(-1, ctx, sortBy, comparer);
             },
-            /**
-             * Sort array in ascending or descending order. It allows sorting on multiple props
-             * in different order for each of them.
-             * @example
-             * sort(users).by([
-             *  { asc: u => u.score }
-             *  { desc: u => u.age }
-             * ]);
-             */
             by: function (sortBy) {
                 return sortArray(1, ctx, sortBy, comparer);
             },
         };
     };
-};
+}
 var defaultComparer = function (a, b, order) {
     if (a == null)
         return order;

--- a/dist/sort.js
+++ b/dist/sort.js
@@ -80,55 +80,25 @@
       }
       return ctx.sort(getSortStrategy(sortBy, comparer, order));
   };
-  // >>> Public <<<
-  var createNewSortInstance = function (opts) {
+  function createNewSortInstance(opts) {
       var comparer = castComparer(opts.comparer);
       return function (_ctx) {
           var ctx = Array.isArray(_ctx) && !opts.inPlaceSorting
               ? _ctx.slice()
               : _ctx;
           return {
-              /**
-               * Sort array in ascending order.
-               * @example
-               * sort([3, 1, 4]).asc();
-               * sort(users).asc(u => u.firstName);
-               * sort(users).asc([
-               *   U => u.firstName
-               *   u => u.lastName,
-               * ]);
-               */
               asc: function (sortBy) {
                   return sortArray(1, ctx, sortBy, comparer);
               },
-              /**
-               * Sort array in descending order.
-               * @example
-               * sort([3, 1, 4]).desc();
-               * sort(users).desc(u => u.firstName);
-               * sort(users).desc([
-               *   U => u.firstName
-               *   u => u.lastName,
-               * ]);
-               */
               desc: function (sortBy) {
                   return sortArray(-1, ctx, sortBy, comparer);
               },
-              /**
-               * Sort array in ascending or descending order. It allows sorting on multiple props
-               * in different order for each of them.
-               * @example
-               * sort(users).by([
-               *  { asc: u => u.score }
-               *  { desc: u => u.age }
-               * ]);
-               */
               by: function (sortBy) {
                   return sortArray(1, ctx, sortBy, comparer);
               },
           };
       };
-  };
+  }
   var defaultComparer = function (a, b, order) {
       if (a == null)
           return order;

--- a/dist/sort.min.d.ts
+++ b/dist/sort.min.d.ts
@@ -17,7 +17,7 @@ export interface ISortByDescSorter<T> extends ISortInstanceOptions {
     desc: boolean | ISortBy<T>;
 }
 export declare type ISortByObjectSorter<T> = ISortByAscSorter<T> | ISortByDescSorter<T>;
-export declare const createNewSortInstance: (opts: ISortInstanceOptions) => <T>(_ctx: T[]) => {
+interface ISortFunctions<T> {
     /**
      * Sort array in ascending order.
      * @example
@@ -50,73 +50,11 @@ export declare const createNewSortInstance: (opts: ISortInstanceOptions) => <T>(
      * ]);
      */
     by(sortBy: ISortByObjectSorter<T> | ISortByObjectSorter<T>[]): T[];
-};
-export declare const sort: <T>(_ctx: T[]) => {
-    /**
-     * Sort array in ascending order.
-     * @example
-     * sort([3, 1, 4]).asc();
-     * sort(users).asc(u => u.firstName);
-     * sort(users).asc([
-     *   U => u.firstName
-     *   u => u.lastName,
-     * ]);
-     */
-    asc(sortBy?: ISortBy<T> | ISortBy<T>[]): T[];
-    /**
-     * Sort array in descending order.
-     * @example
-     * sort([3, 1, 4]).desc();
-     * sort(users).desc(u => u.firstName);
-     * sort(users).desc([
-     *   U => u.firstName
-     *   u => u.lastName,
-     * ]);
-     */
-    desc(sortBy?: ISortBy<T> | ISortBy<T>[]): T[];
-    /**
-     * Sort array in ascending or descending order. It allows sorting on multiple props
-     * in different order for each of them.
-     * @example
-     * sort(users).by([
-     *  { asc: u => u.score }
-     *  { desc: u => u.age }
-     * ]);
-     */
-    by(sortBy: ISortByObjectSorter<T> | ISortByObjectSorter<T>[]): T[];
-};
-export declare const inPlaceSort: <T>(_ctx: T[]) => {
-    /**
-     * Sort array in ascending order.
-     * @example
-     * sort([3, 1, 4]).asc();
-     * sort(users).asc(u => u.firstName);
-     * sort(users).asc([
-     *   U => u.firstName
-     *   u => u.lastName,
-     * ]);
-     */
-    asc(sortBy?: ISortBy<T> | ISortBy<T>[]): T[];
-    /**
-     * Sort array in descending order.
-     * @example
-     * sort([3, 1, 4]).desc();
-     * sort(users).desc(u => u.firstName);
-     * sort(users).desc([
-     *   U => u.firstName
-     *   u => u.lastName,
-     * ]);
-     */
-    desc(sortBy?: ISortBy<T> | ISortBy<T>[]): T[];
-    /**
-     * Sort array in ascending or descending order. It allows sorting on multiple props
-     * in different order for each of them.
-     * @example
-     * sort(users).by([
-     *  { asc: u => u.score }
-     *  { desc: u => u.age }
-     * ]);
-     */
-    by(sortBy: ISortByObjectSorter<T> | ISortByObjectSorter<T>[]): T[];
-};
+}
+export declare function createNewSortInstance(opts: ISortInstanceOptions & {
+    inPlaceSorting?: false;
+}): <T>(_ctx: readonly T[]) => ISortFunctions<T>;
+export declare function createNewSortInstance(opts: ISortInstanceOptions): <T>(_ctx: T[]) => ISortFunctions<T>;
+export declare const sort: <T>(_ctx: readonly T[]) => ISortFunctions<T>;
+export declare const inPlaceSort: <T>(_ctx: T[]) => ISortFunctions<T>;
 export {};

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -149,52 +149,60 @@ const sortArray = function(order:IOrder, ctx:any[], sortBy:IAnySortBy, comparer:
   return ctx.sort(getSortStrategy(sortBy, comparer, order));
 };
 
+interface ISortFunctions<T> {
+  /**
+   * Sort array in ascending order.
+   * @example
+   * sort([3, 1, 4]).asc();
+   * sort(users).asc(u => u.firstName);
+   * sort(users).asc([
+   *   U => u.firstName
+   *   u => u.lastName,
+   * ]);
+   */
+  asc(sortBy?:ISortBy<T> | ISortBy<T>[]):T[]
+  /**
+   * Sort array in descending order.
+   * @example
+   * sort([3, 1, 4]).desc();
+   * sort(users).desc(u => u.firstName);
+   * sort(users).desc([
+   *   U => u.firstName
+   *   u => u.lastName,
+   * ]);
+   */
+  desc(sortBy?:ISortBy<T> | ISortBy<T>[]):T[]
+  /**
+   * Sort array in ascending or descending order. It allows sorting on multiple props
+   * in different order for each of them.
+   * @example
+   * sort(users).by([
+   *  { asc: u => u.score }
+   *  { desc: u => u.age }
+   * ]);
+   */
+  by(sortBy:ISortByObjectSorter<T> | ISortByObjectSorter<T>[]):T[]
+}
+
 // >>> Public <<<
 
-export const createNewSortInstance = function(opts:ISortInstanceOptions) {
+export function createNewSortInstance(opts:ISortInstanceOptions & { inPlaceSorting?: false }): <T>(_ctx: readonly T[]) => ISortFunctions<T>
+export function createNewSortInstance(opts:ISortInstanceOptions): <T>(_ctx: T[]) => ISortFunctions<T>
+export function createNewSortInstance(opts:ISortInstanceOptions) {
   const comparer = castComparer(opts.comparer);
 
-  return function<T>(_ctx:T[]) {
+  return function<T>(_ctx:T[]): ISortFunctions<T> {
     const ctx = Array.isArray(_ctx) && !opts.inPlaceSorting
       ? _ctx.slice()
       : _ctx;
 
     return {
-      /**
-       * Sort array in ascending order.
-       * @example
-       * sort([3, 1, 4]).asc();
-       * sort(users).asc(u => u.firstName);
-       * sort(users).asc([
-       *   U => u.firstName
-       *   u => u.lastName,
-       * ]);
-       */
       asc(sortBy?:ISortBy<T> | ISortBy<T>[]):T[] {
         return sortArray(1, ctx, sortBy, comparer);
       },
-      /**
-       * Sort array in descending order.
-       * @example
-       * sort([3, 1, 4]).desc();
-       * sort(users).desc(u => u.firstName);
-       * sort(users).desc([
-       *   U => u.firstName
-       *   u => u.lastName,
-       * ]);
-       */
       desc(sortBy?:ISortBy<T> | ISortBy<T>[]):T[] {
         return sortArray(-1, ctx, sortBy, comparer);
       },
-      /**
-       * Sort array in ascending or descending order. It allows sorting on multiple props
-       * in different order for each of them.
-       * @example
-       * sort(users).by([
-       *  { asc: u => u.score }
-       *  { desc: u => u.age }
-       * ]);
-       */
       by(sortBy:ISortByObjectSorter<T> | ISortByObjectSorter<T>[]):T[] {
         return sortArray(1, ctx, sortBy, comparer);
       },


### PR DESCRIPTION
This adds overloading to the `createNewSortInstance` to accept `readonly` arrays when `inPlaceSorting` is known to be false at compile time.